### PR TITLE
chore: renovate to allow only java lts version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["org.openjfx:javafx-controls", "org.openjfx:javafx-web", "org.openjfx:javafx-base", "org.openjfx:javafx-fxml"],
+      "allowedVersions": "!/ea/"
+    }
+  ],
   "stabilityDays": 30,
   "baseBranches": ["develop"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
-  "ignorePresets": ["workarounds:javaLTSVersions"],
   "stabilityDays": 30,
   "baseBranches": ["develop"]
 }


### PR DESCRIPTION
_Those who can read (and are not tired) have a clear advantage_

Reverts Aclrian/MessdienerPlanErsteller#142
If I find it out, also ea version of java will be ignored.